### PR TITLE
add no_intra_emphasis extension

### DIFF
--- a/realtime_markdown_viewer.rb
+++ b/realtime_markdown_viewer.rb
@@ -29,7 +29,7 @@ get '/emacs' do
     ws.onopen { puts "@@ connect from emacs" }
     ws.onmessage do |msg|
       renderer = HTMLwithCoderay.new()
-      markdown = Redcarpet::Markdown.new(renderer, :fenced_code_blocks => true)
+      markdown = Redcarpet::Markdown.new(renderer, :fenced_code_blocks => true, :no_intra_emphasis => true)
       html = markdown.render(msg)
       EM.next_tick do
         settings.sockets.each{|s| s.send(html) }


### PR DESCRIPTION
markdown中に

<pre>$a_1, a_2$</pre>

とかくと、
`<p>$a<em>1, a</em>2$</p>`
というhtmlに変換されてしまっていたので、
`<p>$a_1, a_2$</p>`
となるように修正しました。
